### PR TITLE
allow the use of empty interface as request type for handlers for http m...

### DIFF
--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -183,6 +183,19 @@ func TestBody(t *testing.T) {
 	}
 }
 
+func Test500OnMisconfiguredPost(t *testing.T) {
+	w := &testResponseWriter{}
+	r, _ := http.NewRequest("POST", "http://example.com/foo", bytes.NewBufferString("anything"))
+	r.Header.Set("Accept", "application/json")
+	r.Header.Set("Content-Type", "application/json")
+	Marshaled(func(u *url.URL, h http.Header, _ interface{}) (int, http.Header, *testResponse, error) {
+		return http.StatusOK, nil, &testResponse{"bar"}, nil
+	}).ServeHTTP(w, r)
+	if http.StatusInternalServerError != w.Status {
+		t.Fatalf("Server did not 500 when trying to handle a POST to a handler with interface{} as the request type")
+	}
+}
+
 func testMarshaledPanic(i interface{}, t *testing.T) {
 	defer func() {
 		err := recover()


### PR DESCRIPTION
...ethods that do not require a body

Handle functions are now allowed to have interface{} as the request type
so that methods that are only ever invoked via GET don't have to create
some special request type only to be ignored. The Marshaler has been
modified to error our appropriately when interface{} is used in a
handler for an HTTP method that requires a request body and to log a
warning when a method that does not require a body is registered with a
request type
