### PR TITLE
catch a failure-inducing request body configuration

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -51,6 +51,11 @@ func Marshaled(i interface{}) *Marshaler {
 			t.Out(2),
 		))
 	}
+	if t.In(2).Kind() == reflect.Slice {
+		panic(NewMarshalerError(
+			"Slice used as request body argument. Use pointer to slice instead.",
+		))
+	}
 	if 4 != t.NumOut() {
 		panic(NewMarshalerError("output arity was %v, not 4", t.NumOut()))
 	}


### PR DESCRIPTION
Not sure this is the correct fix, but thought I'd throw the PR up for discussion.

The issue is, Tigertonic happily allows a []foo request body in the signature, but when you actually hit that endpoint, it errors because `.Elem()` on a slice happily returns the type of the slice, and `json.Unmarshal` then tries to fit a []foo into a foo. Example:

```
23:06:07.718794 DMyN2NKppwYakxQE < {"description":"json: cannot unmarshal array into Go value of type event.JsonEvent","error":"json.UnmarshalTypeError"}
```

The code that performs the reflection in question is at [`marshaler.go#101-105`](https://github.com/rcrowley/go-tigertonic/blob/ebb4327742a72c172bf7e1bcc6cc55388d9cd9f0/marshaler.go#L101-105)

``` go
    if reflect.Interface == in2.Kind() && 0 == in2.NumMethod() {
        rq = nilRequest
    } else {
        rq = reflect.New(in2.Elem())
    }
```

Perhaps that can somehow be fixed to accommodate non-pointer slices instead?
