### PR TITLE
Fix apache logger test

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -33,7 +33,7 @@ func TestApacheLogger(t *testing.T) {
 	logger.Logger = log.New(b, "", 0)
 	logger.ServeHTTP(w, r)
 	s := b.String()
-	if ok, _ := regexp.MatchString(`^127.0.0.1:48879 - rcrowley \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{1,9} \+\d{4} [A-Z]{3}\] "GET " 200 14 "http://example.com/" "Tiger Tonic tests"\n$`, s); !ok {
+	if ok, _ := regexp.MatchString(`^127\.0\.0\.1:48879 - rcrowley \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{1,9} [+-]\d{4} [A-Z]{3}\] "GET " 200 14 "http://example.com/" "Tiger Tonic tests"\n$`, s); !ok {
 		t.Fatal(s)
 	}
 }


### PR DESCRIPTION
The timezone portion of the timestamp printed out was looking for a '+'.
This could be either a '+' or '-' according to the timezone set on the
server running the tests. In an ideal this world, this would be +0000,
but we don't live in an ideal world.
