### PR TITLE
slightly more helpful error message

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -65,7 +65,7 @@ func Marshaled(i interface{}) *Marshaler {
 	}
 	if !t.Out(2).Implements(reflect.TypeOf((*interface{})(nil)).Elem()) {
 		panic(NewMarshalerError(
-			"type of third return value was %v, not Response",
+			"type of third return value was %v, not a pointer to a response struct",
 			t.Out(2),
 		))
 	}


### PR DESCRIPTION
minor, but can still contribute to confusion for a user that is new to the framework and doesn't realize that the response has to be a pointer.
