### PR TITLE
Fix issue #47: Embed Err instead of error

### DIFF
--- a/http_equiv_error.go
+++ b/http_equiv_error.go
@@ -7,253 +7,256 @@ import "net/http"
 // "tigertonic.NotFound".
 var SnakeCaseHTTPEquivErrors bool
 
+// Err is a type alias for `error` so that it can be publicly exported when embedding
+type Err error
+
 type HTTPEquivError interface {
 	error
 	Status() int
 }
 
 type Continue struct {
-	error
+	Err
 }
 
 func (err Continue) Status() int { return http.StatusContinue }
 
 type SwitchingProtocols struct {
-	error
+	Err
 }
 
 func (err SwitchingProtocols) Status() int { return http.StatusSwitchingProtocols }
 
 type OK struct {
-	error
+	Err
 }
 
 func (err OK) Status() int { return http.StatusOK }
 
 type Created struct {
-	error
+	Err
 }
 
 func (err Created) Status() int { return http.StatusCreated }
 
 type Accepted struct {
-	error
+	Err
 }
 
 func (err Accepted) Status() int { return http.StatusAccepted }
 
 type NonAuthoritativeInfo struct {
-	error
+	Err
 }
 
 func (err NonAuthoritativeInfo) Status() int { return http.StatusNonAuthoritativeInfo }
 
 type NoContent struct {
-	error
+	Err
 }
 
 func (err NoContent) Status() int { return http.StatusNoContent }
 
 type ResetContent struct {
-	error
+	Err
 }
 
 func (err ResetContent) Status() int { return http.StatusResetContent }
 
 type PartialContent struct {
-	error
+	Err
 }
 
 func (err PartialContent) Status() int { return http.StatusPartialContent }
 
 type MultipleChoices struct {
-	error
+	Err
 }
 
 func (err MultipleChoices) Status() int { return http.StatusMultipleChoices }
 
 type MovedPermanently struct {
-	error
+	Err
 }
 
 func (err MovedPermanently) Status() int { return http.StatusMovedPermanently }
 
 type Found struct {
-	error
+	Err
 }
 
 func (err Found) Status() int { return http.StatusFound }
 
 type SeeOther struct {
-	error
+	Err
 }
 
 func (err SeeOther) Status() int { return http.StatusSeeOther }
 
 type NotModified struct {
-	error
+	Err
 }
 
 func (err NotModified) Status() int { return http.StatusNotModified }
 
 type UseProxy struct {
-	error
+	Err
 }
 
 func (err UseProxy) Status() int { return http.StatusUseProxy }
 
 type TemporaryRedirect struct {
-	error
+	Err
 }
 
 func (err TemporaryRedirect) Status() int { return http.StatusTemporaryRedirect }
 
 type BadRequest struct {
-	error
+	Err
 }
 
 func (err BadRequest) Status() int { return http.StatusBadRequest }
 
 type Unauthorized struct {
-	error
+	Err
 }
 
 func (err Unauthorized) Status() int { return http.StatusUnauthorized }
 
 type PaymentRequired struct {
-	error
+	Err
 }
 
 func (err PaymentRequired) Status() int { return http.StatusPaymentRequired }
 
 type Forbidden struct {
-	error
+	Err
 }
 
 func (err Forbidden) Status() int { return http.StatusForbidden }
 
 type NotFound struct {
-	error
+	Err
 }
 
 func (err NotFound) Status() int { return http.StatusNotFound }
 
 type MethodNotAllowed struct {
-	error
+	Err
 }
 
 func (err MethodNotAllowed) Status() int { return http.StatusMethodNotAllowed }
 
 type NotAcceptable struct {
-	error
+	Err
 }
 
 func (err NotAcceptable) Status() int { return http.StatusNotAcceptable }
 
 type ProxyAuthRequired struct {
-	error
+	Err
 }
 
 func (err ProxyAuthRequired) Status() int { return http.StatusProxyAuthRequired }
 
 type RequestTimeout struct {
-	error
+	Err
 }
 
 func (err RequestTimeout) Status() int { return http.StatusRequestTimeout }
 
 type Conflict struct {
-	error
+	Err
 }
 
 func (err Conflict) Status() int { return http.StatusConflict }
 
 type Gone struct {
-	error
+	Err
 }
 
 func (err Gone) Status() int { return http.StatusGone }
 
 type LengthRequired struct {
-	error
+	Err
 }
 
 func (err LengthRequired) Status() int { return http.StatusLengthRequired }
 
 type PreconditionFailed struct {
-	error
+	Err
 }
 
 func (err PreconditionFailed) Status() int { return http.StatusPreconditionFailed }
 
 type RequestEntityTooLarge struct {
-	error
+	Err
 }
 
 func (err RequestEntityTooLarge) Status() int { return http.StatusRequestEntityTooLarge }
 
 type RequestURITooLong struct {
-	error
+	Err
 }
 
 func (err RequestURITooLong) Status() int { return http.StatusRequestURITooLong }
 
 type UnsupportedMediaType struct {
-	error
+	Err
 }
 
 func (err UnsupportedMediaType) Status() int { return http.StatusUnsupportedMediaType }
 
 type RequestedRangeNotSatisfiable struct {
-	error
+	Err
 }
 
 func (err RequestedRangeNotSatisfiable) Status() int { return http.StatusRequestedRangeNotSatisfiable }
 
 type ExpectationFailed struct {
-	error
+	Err
 }
 
 func (err ExpectationFailed) Status() int { return http.StatusExpectationFailed }
 
 type Teapot struct {
-	error
+	Err
 }
 
 func (err Teapot) Status() int { return http.StatusTeapot }
 
 type InternalServerError struct {
-	error
+	Err
 }
 
 func (err InternalServerError) Status() int { return http.StatusInternalServerError }
 
 type NotImplemented struct {
-	error
+	Err
 }
 
 func (err NotImplemented) Status() int { return http.StatusNotImplemented }
 
 type BadGateway struct {
-	error
+	Err
 }
 
 func (err BadGateway) Status() int { return http.StatusBadGateway }
 
 type ServiceUnavailable struct {
-	error
+	Err
 }
 
 func (err ServiceUnavailable) Status() int { return http.StatusServiceUnavailable }
 
 type GatewayTimeout struct {
-	error
+	Err
 }
 
 func (err GatewayTimeout) Status() int { return http.StatusGatewayTimeout }
 
 type HTTPVersionNotSupported struct {
-	error
+	Err
 }
 
 func (err HTTPVersionNotSupported) Status() int { return http.StatusHTTPVersionNotSupported }


### PR DESCRIPTION
go1.2 enforces that assignment cannot happen to an unexported field.
Make a type alias for `error` that will be publicly exported and embed
that type instead.

More details: https://github.com/rcrowley/go-tigertonic/issues/47
