### PR TITLE
fix mocking.URL to not panic(nil)

### DIFF
--- a/mocking/mocking.go
+++ b/mocking/mocking.go
@@ -44,11 +44,11 @@ func URL(h TestableHandler, method, rawurl string) *url.URL {
 		var ok bool
 		for {
 			h1, _ := h.Handler(rq)
-			if _, ok := h1.(tigertonic.NotFoundHandler); ok {
-				panic(err)
+			if h, ok := h1.(tigertonic.NotFoundHandler); ok {
+				panic(h)
 			}
-			if _, ok := h1.(tigertonic.MethodNotAllowedHandler); ok {
-				panic(err)
+			if h, ok := h1.(tigertonic.MethodNotAllowedHandler); ok {
+				panic(h)
 			}
 			if h, ok = h1.(TestableHandler); !ok {
 				break


### PR DESCRIPTION
This change makes the panic look like the following:

```
panic: (tigertonic.NotFoundHandler) (0x4a6f20,0x64f400) [recovered]
```

As a side note, panic(nil) causes the test to pass! This isfixed in go1.3,
https://code.google.com/p/go/issues/detail?id=6546
