### PR TITLE
Strip the port from the supplied host before looking up in the hostname map

### DIFF
--- a/host_serve_mux_test.go
+++ b/host_serve_mux_test.go
@@ -41,3 +41,30 @@ func TestHostnameNotFound(t *testing.T) {
 		t.Fatal(w.StatusCode)
 	}
 }
+
+func TestHostnameWithPort(t *testing.T) {
+	mux := NewHostServeMux()
+	mux.HandleFunc("example.com", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	w := &testResponseWriter{}
+	r, _ := http.NewRequest("GET", "http://example.com:80/", nil)
+	mux.ServeHTTP(w, r)
+	if http.StatusNoContent != w.StatusCode {
+		t.Fatal(w.StatusCode)
+	}
+}
+
+func TestHostnameFoundInURLWithPort(t *testing.T) {
+	mux := NewHostServeMux()
+	mux.HandleFunc("example.com", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	w := &testResponseWriter{}
+    r, _ := http.NewRequest("GET", "http://example.com:80/", nil)
+	r.Host = ""
+	mux.ServeHTTP(w, r)
+	if http.StatusNoContent != w.StatusCode {
+		t.Fatal(w.StatusCode)
+	}
+}


### PR DESCRIPTION
This branch is a fix for #61, stripping the port before attempting to lookup in the map.
