### PR TITLE
Marshaler handles when Response pointer is nil.

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -187,7 +187,7 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	w.WriteHeader(code)
-	if nil != rs && http.StatusNoContent != code {
+	if nil != rs && http.StatusNoContent != code && (out[2].Kind() != reflect.Ptr || !out[2].IsNil()) {
 		if err := json.NewEncoder(w).Encode(rs); nil != err {
 			log.Println(err)
 		}

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -200,6 +200,21 @@ func TestNoContent(t *testing.T) {
 	}
 }
 
+func TestNilContent(t *testing.T) {
+	w := &testResponseWriter{}
+	r, _ := http.NewRequest("GET", "http://example.com/foo", nil)
+	r.Header.Set("Accept", "application/json")
+	Marshaled(func(u *url.URL, h http.Header, rq *testRequest) (int, http.Header, *testResponse, error) {
+		return http.StatusOK, nil, nil, nil
+	}).ServeHTTP(w, r)
+	if http.StatusOK != w.StatusCode {
+		t.Fatal(w.StatusCode)
+	}
+	if "" != w.Body.String() {
+		t.Fatal(w.Body.String())
+	}
+}
+
 func TestHeader(t *testing.T) {
 	w := &testResponseWriter{}
 	r, _ := http.NewRequest("GET", "http://example.com/foo", nil)


### PR DESCRIPTION
If a nil returned as *Response the previous solution returned a "null\n" string representation. It turned out that nil != rs handles empty interfaces but not nil pointers. This approach returns an empty string for both case.
