### PR TITLE
Allow no body when Content-Type = 0

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -107,7 +107,7 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rq = nilRequest
 	}
 	if "PATCH" == r.Method || "POST" == r.Method || "PUT" == r.Method {
-		if rq == nilRequest {
+		if rq == nilRequest && "0" != r.Header.Get("Content-Type") {
 			writeJSONError(w, NewMarshalerError(
 				"empty interface is not suitable for %s request bodies",
 				r.Method,
@@ -126,7 +126,7 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		decoder := reflect.ValueOf(json.NewDecoder(r.Body))
 		out := decoder.MethodByName("Decode").Call([]reflect.Value{rq})
-		if !out[0].IsNil() {
+		if !out[0].IsNil() && "0" != r.Header.Get("Content-Type") {
 			writeJSONError(w, NewHTTPEquivError(
 				out[0].Interface().(error),
 				http.StatusBadRequest,


### PR DESCRIPTION
The HTTP spec is ambiguous in determining if a request could have no body when the method is POST, PUT, or PATCH.  Some popular HTTP server, like nginx, adopt the policy that a request of the aforementioned methods with no body is allowed if and only if it has the header Content-Length set to 0.

It makes sense not to try to marshal the body when Content-Length has that value.

I understand that an empty body is not the same as no body, and this is why I said the spec is ambiguous.  Even though a request of such methods with no body might be unRESTful it is useful for implementing "actions".

Would you consider merging this?

Regards,
Alfonso.