### PR TITLE
Move the RequestIDCreator call before the ServeHTTP call

### DIFF
--- a/json_logger.go
+++ b/json_logger.go
@@ -40,6 +40,7 @@ func (jl *JSONLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	tee := NewTeeResponseWriter(w)
 	rURI := r.URL.RequestURI()
 	body := &jsonReadCloser{r.Body, bytes.Buffer{}}
+	requestID := jl.RequestIDCreator(r)
 	r.Body = body
 	jl.handler.ServeHTTP(tee, r)
 	buf, err := json.Marshal(&jsonLog{
@@ -68,7 +69,7 @@ func (jl *JSONLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			tee.StatusCode,
 			http.StatusText(tee.StatusCode),
 		),
-		RequestID: jl.RequestIDCreator(r),
+		RequestID: requestID,
 		Type:      "http",
 	})
 	if err != nil {


### PR DESCRIPTION
This is necessary to be able to store the request ID in the RequestIDCreator before the HTTP handler is called so it's available to the HTTP handler later.