### PR TITLE
Allow Marshaled to respond with arbitrary streams.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ func myHandler(*url.URL, http.Header, *MyRequest) (int, http.Header, *MyResponse
 
 Alternatively, you can return a valid status as the first output parameter and an `error` as the last; that status will be used in the error response.
 
+If the return type of a `tigertonic.Marshaled` handler interface implements the `io.Reader` interface the stream will be written directly to the requestor. A `Content-Type` header is required to be specified in the response headers and the `Accept` header for these particular requests can be anything.
+
+Additionally, if the return type of the `tigertonic.Marshaled` handler implements the `io.Closer` interface the stream will be automatically closed after it is flushed to the requestor.
+
 ### `tigertonic.Logged`, `tigertonic.JSONLogged`, and `tigertonic.ApacheLogged`
 
 Wrap an `http.Handler` in `tigertonic.Logged` to have the request and response headers and bodies logged to standard output.  The second argument is an optional `func(string) string` called as requests and responses are logged to give the caller the opportunity to redact sensitive information from log entries.

--- a/logger.go
+++ b/logger.go
@@ -239,7 +239,9 @@ func (w *multilineLoggerResponseWriter) Write(p []byte) (int, error) {
 	if !w.wroteHeader {
 		w.WriteHeader(http.StatusOK)
 	}
-	if len(p) > 0 && '\n' == p[len(p)-1] {
+	if ct := w.Header().Get("Content-Type"); "" != ct && "application/json" != ct && "text/plain" != ct {
+		w.Println(w.requestID, "<", "** response body redacted **")
+	} else if len(p) > 0 && '\n' == p[len(p)-1] {
 		w.Println(w.requestID, "<", string(p[:len(p)-1]))
 	} else {
 		w.Println(w.requestID, "<", string(p))

--- a/marshaler.go
+++ b/marshaler.go
@@ -3,6 +3,7 @@ package tigertonic
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"reflect"
@@ -77,19 +78,29 @@ func Marshaled(i interface{}) *Marshaler {
 
 // ServeHTTP unmarshals JSON input, handles the request via the function, and
 // marshals JSON output.
+// If the output of the handler function implements io.Reader the headers must
+// contain a 'Content-Type'; the stream will be written directly to the
+// requestor without being marshaled to JSON.
+// Additionally if the output implements the io.Closer the stream will be
+// automatically closed after flushing.
 func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	wHeader := w.Header()
-	if !acceptJSON(r) {
-		wHeader.Set("Content-Type", "text/plain")
-		w.WriteHeader(http.StatusNotAcceptable)
-		fmt.Fprintf(
-			w,
-			"\"%s\" does not contain \"application/json\"",
+	isReader := false
+	isCloser := false
+	if 2 < m.v.Type().NumOut() {
+		out2 := m.v.Type().Out(2)
+		if reflect.Interface == out2.Kind() {
+			isReader = out2.Implements(reflect.TypeOf((*io.Reader)(nil)).Elem())
+			isCloser = out2.Implements(reflect.TypeOf((*io.Closer)(nil)).Elem())
+		}
+	}
+	if !isReader && !acceptJSON(r) {
+		ResponseErrorWriter.WritePlaintextError(w, NewHTTPEquivError(NewMarshalerError(
+			"Accept header %q does not allow \"application/json\"",
 			r.Header.Get("Accept"),
-		)
+		), http.StatusNotAcceptable))
 		return
 	}
-	wHeader.Set("Content-Type", "application/json")
 	var rq reflect.Value
 	if 2 < m.v.Type().NumIn() {
 		in2 := m.v.Type().In(2)
@@ -108,7 +119,7 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if "PATCH" == r.Method || "POST" == r.Method || "PUT" == r.Method {
 		if rq == nilRequest {
-			ResponseErrorWriter.WriteJSONError(w, NewMarshalerError(
+			ResponseErrorWriter.WriteError(r, w, NewMarshalerError(
 				"empty interface is not suitable for %s request bodies",
 				r.Method,
 			))
@@ -118,7 +129,7 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			r.Header.Get("Content-Type"),
 			"application/json",
 		) {
-			ResponseErrorWriter.WriteJSONError(w, NewHTTPEquivError(NewMarshalerError(
+			ResponseErrorWriter.WriteError(r, w, NewHTTPEquivError(NewMarshalerError(
 				"Content-Type header is %s, not application/json",
 				r.Header.Get("Content-Type"),
 			), http.StatusUnsupportedMediaType))
@@ -127,7 +138,7 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		decoder := reflect.ValueOf(json.NewDecoder(r.Body))
 		out := decoder.MethodByName("Decode").Call([]reflect.Value{rq})
 		if !out[0].IsNil() {
-			ResponseErrorWriter.WriteJSONError(w, NewHTTPEquivError(
+			ResponseErrorWriter.WriteError(r, w, NewHTTPEquivError(
 				out[0].Interface().(error),
 				http.StatusBadRequest,
 			))
@@ -172,9 +183,9 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !out[3].IsNil() {
 		err := out[3].Interface().(error)
 		if _, ok := err.(HTTPEquivError); ok {
-			ResponseErrorWriter.WriteJSONError(w, err)
+			ResponseErrorWriter.WriteError(r, w, err)
 		} else {
-			ResponseErrorWriter.WriteJSONError(w, NewHTTPEquivError(err, code))
+			ResponseErrorWriter.WriteError(r, w, NewHTTPEquivError(err, code))
 		}
 		return
 	}
@@ -186,9 +197,39 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	if isReader {
+		contentType := wHeader.Get("Content-Type")
+		if "" == contentType {
+			ResponseErrorWriter.WriteError(r, w, NewHTTPEquivError(NewMarshalerError(
+				"Required Content-Type header missing from stream response"),
+				http.StatusInternalServerError))
+			return
+		}
+		if !acceptContentType(r, contentType) {
+			ResponseErrorWriter.WritePlaintextError(w, NewHTTPEquivError(NewMarshalerError(
+				"Accept header %q does not allow %q",
+				r.Header.Get("Accept"), contentType,
+			), http.StatusNotAcceptable))
+			return
+		}
+	} else {
+		wHeader.Set("Content-Type", "application/json")
+	}
 	w.WriteHeader(code)
 	if nil != rs && http.StatusNoContent != code && (out[2].Kind() != reflect.Ptr || !out[2].IsNil()) {
-		if err := json.NewEncoder(w).Encode(rs); nil != err {
+		if isReader {
+			reader := rs.(io.Reader)
+			_, err := io.Copy(w, reader)
+			if nil != err {
+				log.Println(err)
+			}
+			if isCloser {
+				closer := rs.(io.Closer)
+				if err := closer.Close(); nil != err {
+					log.Println(err)
+				}
+			}
+		} else if err := json.NewEncoder(w).Encode(rs); nil != err {
 			log.Println(err)
 		}
 	}


### PR DESCRIPTION
If the return type of a Marshaled handler interface implements the
io.Reader interface the stream will be written directly to the
requestor. A 'Content-Type' header is required to be specified in the
response headers and the 'Accept' header for these particular requests
can be anything.

Additionally, if the return type of the Marshaled handler implements the
io.Closer interface the stream will be automatically closed after it is
flushed to the requestor.

@wadey 