### PR TITLE
extend Marshaler to DELETE requests

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -117,7 +117,7 @@ func (m *Marshaler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		rq = nilRequest
 	}
-	if "PATCH" == r.Method || "POST" == r.Method || "PUT" == r.Method {
+	if "PATCH" == r.Method || "POST" == r.Method || "PUT" == r.Method || ("DELETE" == r.Method && nilRequest != rq) {
 		if rq == nilRequest {
 			ResponseErrorWriter.WriteError(r, w, NewMarshalerError(
 				"empty interface is not suitable for %s request bodies",


### PR DESCRIPTION
HTTP 1.1 specification (RFC 7231) explicitly permits an
entity body in a DELETE request:
> A payload within a DELETE request message has no defined semantics;
> sending a payload body on a DELETE request might cause some existing
> implementations to reject the request.
> - https://tools.ietf.org/html/rfc7231#section-4.3.5

tigertonic doesn't need to be one of this implementations :-)